### PR TITLE
Fix for lens-4.5

### DIFF
--- a/lib/Distribution/PackDeps/Lens/Machinery.hs
+++ b/lib/Distribution/PackDeps/Lens/Machinery.hs
@@ -4,8 +4,8 @@ import Control.Lens ((&), (.~))
 import Control.Lens.TH (DefName(..), lensField, lensRules, makeLensesWith)
 import Language.Haskell.TH.Syntax (Dec, Name, Q, mkName, nameBase)
 
-fieldName :: (String -> String) -> [Name] -> Name -> [DefName]
-fieldName f _ name = [TopName . mkName . f . nameBase $ name]
+fieldName :: (String -> String) -> Name -> [Name] -> Name -> [DefName]
+fieldName f _ _ name = [TopName . mkName . f . nameBase $ name]
 
 makeLenses :: Name -> Q [Dec]
 makeLenses = makeLensesWith (lensRules & lensField .~ fieldName id)

--- a/packrank.cabal
+++ b/packrank.cabal
@@ -29,7 +29,7 @@ library
     base >=4.3 && <5,
     binary,
     containers,
-    lens >= 0.4.4,
+    lens >= 0.4.5,
     packdeps >= 0.4.0.2,
     template-haskell,
     vector,


### PR DESCRIPTION
Fix `Distribution.PackDeps.Lens.Machinery` so that `packrank` builds correctly with the latest version of `lens` (4.5).
