### PR TITLE
Fix for GHC 7.10

### DIFF
--- a/lib/Distribution/PackRank.hs
+++ b/lib/Distribution/PackRank.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE BangPatterns, DeriveGeneric, GeneralizedNewtypeDeriving,
-    RecordWildCards, ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns, DeriveGeneric, FlexibleContexts,
+    GeneralizedNewtypeDeriving, RecordWildCards, ScopedTypeVariables #-}
 
 module Distribution.PackRank
     (


### PR DESCRIPTION
GHC 7.10 now infers `FlexibleContexts` in `Distribution.PackRank`.
